### PR TITLE
Added onlyReturnUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Given an value, `unit-parse` will be able to parse the following units:
 ```js
 const parseUnit = require('unit-parse');
 
-console.log(parseUnit('20px')); // { value: '20', unit: 'px' }
-console.log(parseUnit('15%')); // { value: '15', unit: '%' }
-console.log(parseUnit('-1.5s')); // { value: '-1.5', unit: 's' }
+parseUnit('20px'); // { value: '20', unit: 'px' }
+parseUnit('15%'); // { value: '15', unit: '%' }
+parseUnit('-1.5s'); // { value: '-1.5', unit: 's' }
+
+parseUnit('20px', true); // 'px'
+parseUnit('15%', true); // '%'
+parseUnit('-1.5s', true); // 's'
 ```
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
-module.exports = (value) => {
+module.exports = (value, onlyReturnUnit = false) => {
     const regex = /^(0?[-.]?\d+)(r?e[m|x]|v[h|w|min|max]+|p[x|t|c]|[c|m]m|%|s|in|ch)$/;
     const match = value.match(regex);
+
+    if (onlyReturnUnit === true) {
+        return match ? match[2] : undefined;
+    }
 
     return match
         ? { value: (parseFloat(match[1]) || match[1]), unit: match[2] }

--- a/index.test.js
+++ b/index.test.js
@@ -35,6 +35,14 @@ test('can convert values with decimal point', () => {
     });
 });
 
+test('can return only the unit', () => {
+    expect(parseUnit('19rem', true)).toBe('rem');
+});
+
+test('returns undefined when asking for a value without a unit', () => {
+    expect(parseUnit('50', true)).toBe(undefined);
+});
+
 test('cannot convert unknown units', () => {
     const unit = parseUnit('20m');
 


### PR DESCRIPTION
When onlyReturnUnit is set to true, only the unit will be returned
instead of an object with both the value and unit.